### PR TITLE
Missing Accept-Encoding header should not result in compression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ module.exports = (options = {}) => {
     const encodings = new Encodings({
       preferredEncodings
     })
-    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || undefined)
+    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || 'identity')
     const encoding = encodings.getPreferredContentEncoding()
 
     // identity === no compression


### PR DESCRIPTION
I found that the existing test was not valid, because the `supertest` library provides a default value for Accept-Encoding, so the test for a missing Accept-Encoding header was just testing what happens with the default Accept-Encoding header.

Unfortunately the tests won't pass without a patch to `superagent`: https://github.com/visionmedia/superagent/pull/1560